### PR TITLE
Fusion mags

### DIFF
--- a/ctf_ranged/energy_gen.lua
+++ b/ctf_ranged/energy_gen.lua
@@ -87,6 +87,10 @@ if ctf_ranged.settings.craft_energy_weapons == true then
     })
 end
 
+local fusion_pistol = ItemStack("ctf_ranged:fusion_pistol_loaded")
+local fusion_rifle = ItemStack("ctf_ranged:fusion_rifle_loaded")
+local fusion_shotgun = ItemStack("ctf_ranged:fusion_shotgun_loaded")
+
 -- Fusion Globalstep (Does reloading of loaded fusion energy weapons)
 local fusion_interval = 0.0
 minetest.register_globalstep(function (delta)
@@ -96,7 +100,7 @@ minetest.register_globalstep(function (delta)
             local pname = player:get_player_name()
             local pinv = player:get_inventory()
             -- Only process if a player has any of the 3 fusion energy weapons
-            if pinv:contains_item("ctf_ranged:fusion_pistol_loaded") or pinv:contains_item("ctf_ranged:fusion_rifle_loaded") or pinv:contains_item("ctf_ranged:fusion_shotgun_loaded") then
+            if pinv:contains_item("main", fusion_pistol) or pinv:contains_item("main", fusion_rifle) or pinv:contains_item("main", fusion_shotgun) then
                 -- Iterate main inventory
                 for i, stack in pairs(pinv:get_list("main")) do
                     -- Only work on stuff not empty things
@@ -128,17 +132,17 @@ end)
 -- Allow Energy upgrading to Fusion?
 if ctf_ranged.settings.allow_energy_fusion == true then
     minetest.register_craft({
-        type = "shapeless"
+        type = "shapeless",
         output = "ctf_ranged:fusion_pistol",
         recipe = {"ctf_ranged:energy_pistol", "ctf_ranged:gunparte"}
     })
     minetest.register_craft({
-        type = "shapeless"
+        type = "shapeless",
         output = "ctf_ranged:fusion_rifle",
         recipe = {"ctf_ranged:energy_rifle", "ctf_ranged:gunparte"}
     })
     minetest.register_craft({
-        type = "shapeless"
+        type = "shapeless",
         output = "ctf_ranged:fusion_shotgun",
         recipe = {"ctf_ranged:energy_shotgun", "ctf_ranged:gunparte"}
     })

--- a/ctf_ranged/energy_gen.lua
+++ b/ctf_ranged/energy_gen.lua
@@ -86,3 +86,60 @@ if ctf_ranged.settings.craft_energy_weapons == true then
         }
     })
 end
+
+-- Fusion Globalstep (Does reloading of loaded fusion energy weapons)
+local fusion_interval = 0.0
+minetest.register_globalstep(function (delta)
+    fusion_interval = fusion_interval - delta
+    if fusion_interval <= 0.0 then
+        for _, player in ipairs(minetest.get_connected_players()) do
+            local pname = player:get_player_name()
+            local pinv = player:get_inventory()
+            -- Only process if a player has any of the 3 fusion energy weapons
+            if pinv:contains_item("ctf_ranged:fusion_pistol_loaded") or pinv:contains_item("ctf_ranged:fusion_rifle_loaded") or pinv:contains_item("ctf_ranged:fusion_shotgun_loaded") then
+                -- Iterate main inventory
+                for i, stack in pairs(pinv:get_list("main")) do
+                    -- Only work on stuff not empty things
+                    if not stack:is_empty() then
+                        local name = stack:get_name()
+                        -- Only trigger on any of the fusion weapons
+                        if name:sub(1,17) == "ctf_ranged:fusion" then
+                            -- Only trigger on damaged items
+                            if stack:get_wear() ~= 0 then
+                                -- Add reverse wear and update the stack (optional do debug)
+                                stack:add_wear( -ctf_ranged.settings.fusion_reload_speed )
+                                pinv:set_stack("main", i, stack)
+                                if minetest.settings:get_bool("show_debug") == true then -- Come up with a better setting to use and replace this one
+                                    -- Debug info (With example of what it could look like in logs, debug.txt)
+                                    -- [ctf_ranged] 'ctf_ranged:fusion_pistol_loaded' at 1 in main inv of 'test_subject' now has wear 160.
+                                    -- Note: the wear it is showing is inverted (max size of int16, 65535), so lower is better (higher means the gun has more wear)
+                                    minetest.log("action", "[ctf_ranged] '"..name.."' at "..tostring(i).." in main inv of '"..pname.."' now has wear "..tostring(stack:get_wear())..".")
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+        fusion_interval = 1.0
+    end
+end)
+
+-- Allow Energy upgrading to Fusion?
+if ctf_ranged.settings.allow_energy_fusion == true then
+    minetest.register_craft({
+        type = "shapeless"
+        output = "ctf_ranged:fusion_pistol",
+        recipe = {"ctf_ranged:energy_pistol", "ctf_ranged:gunparte"}
+    })
+    minetest.register_craft({
+        type = "shapeless"
+        output = "ctf_ranged:fusion_rifle",
+        recipe = {"ctf_ranged:energy_rifle", "ctf_ranged:gunparte"}
+    })
+    minetest.register_craft({
+        type = "shapeless"
+        output = "ctf_ranged:fusion_shotgun",
+        recipe = {"ctf_ranged:energy_shotgun", "ctf_ranged:gunparte"}
+    })
+end

--- a/ctf_ranged/settings.lua
+++ b/ctf_ranged/settings.lua
@@ -43,3 +43,18 @@ if settings.craft_energy_weapons == nil then
     settings.craft_energy_weapons = true
     minetest.settings:set_bool("ctf_guns.craft_energy_weapons", settings.craft_energy_weapons)
 end
+
+settings.allow_energy_fusion = minetest.settings:get_bool("ctf_guns.allow_energy_fusion")
+if settings.allow_energy_fusion == nil then
+    settings.allow_energy_fusion = true
+    minetest.settings:set_bool("ctf_guns.allow_energy_fusion", settings.allow_energy_fusion)
+end
+
+settings.fusion_reload_speed = minetest.settings:get("ctf_guns.fusion_reload_speed")
+if settings.fusion_reload_speed == nil then
+    settings.fusion_reload_speed = 1
+    minetest.settings:set("ctf_guns.fusion_reload_speed", settings.fusion_reload_speed)
+else
+    -- This value is actually percent of max durability (int16, 65535)
+    settings.fusion_reload_speed = math.floor((tonumber(settings.fusion_reload_speed) / 100.0) * 65535.0)
+end

--- a/ctf_ranged/settings.lua
+++ b/ctf_ranged/settings.lua
@@ -52,7 +52,7 @@ end
 
 settings.fusion_reload_speed = minetest.settings:get("ctf_guns.fusion_reload_speed")
 if settings.fusion_reload_speed == nil then
-    settings.fusion_reload_speed = 1
+    settings.fusion_reload_speed = 3
     minetest.settings:set("ctf_guns.fusion_reload_speed", settings.fusion_reload_speed)
 else
     -- This value is actually percent of max durability (int16, 65535)

--- a/ctf_ranged/settingtypes.txt
+++ b/ctf_ranged/settingtypes.txt
@@ -12,3 +12,8 @@ ctf_guns.craft_tier2_weapons (Craft Tier 2 Weapons) bool true
 ctf_guns.craft_tier3_weapons (Craft Tier 3 Weapons) bool true
 
 ctf_guns.craft_energy_weapons (Craft Energy Weapons) bool true
+
+ctf_guns.allow_energy_fusion (Allow Upgrading Energy Weapons to Fusion Energy Weapons) bool true
+
+# In percent how fast a Fusion weapon will reload
+ctf_guns.fusion_reload_speed (Fusion Reload Speed) int 1

--- a/ctf_ranged/wep_defns.lua
+++ b/ctf_ranged/wep_defns.lua
@@ -27,6 +27,10 @@
    - E: ctf_ranged:energy_pistol
    - E: ctf_ranged:energy_rifle
    - E: ctf_ranged:energy_shotgun
+   Fusion Energy weapons:
+   - E: ctf_ranged:fuison_pistol
+   - E: ctf_ranged:fusion_rifle
+   - E: ctf_ranged:fusion_shotgun
 
 ]]--
 
@@ -442,4 +446,65 @@ ctf_ranged.simple_register_gun("ctf_ranged:energy_shotgun", {
 	bullet_image = "ctf_ranged_ebullet",
 	bullethole_image = "ctf_ranged_ebullethole",
 	ammo = "ctf_ranged:eammo"
+})
+
+--------------------------
+-- Fusion Energy weapons
+--------------------------
+
+ctf_ranged.simple_register_gun("ctf_ranged:fusion_pistol", {
+	type = "pistol",
+	description = "Laser Blaster (Fusion)",
+	texture = "rangedweapons_laser_blaster.png",
+	fire_sound = "ctf_ranged_dzap",
+	rounds = 20,
+	range = 85,
+	damage = 4,
+	automatic = false,
+	fire_interval = 0.35,
+	liquid_travel_dist = 2,
+	bullet_image = "ctf_ranged_ebullet",
+	bullethole_image = "ctf_ranged_ebullethole",
+	ammo = "ctf_ranged:eammo",
+	fusion_mag = true
+})
+
+ctf_ranged.simple_register_gun("ctf_ranged:fusion_rifle", {
+	type = "smg",
+	description = "Laser Rifle (Fusion)",
+	texture = "rangedweapons_laser_rifle.png",
+	fire_sound = "ctf_ranged_dzap",
+	bullet = {
+	   spread = 1.0,
+	},
+	automatic = true,
+	rounds = 30,
+	range = 75,
+	damage = 7,
+	fire_interval = 0.25,
+	liquid_travel_dist = 2,
+	bullet_image = "ctf_ranged_ebullet",
+	bullethole_image = "ctf_ranged_ebullethole",
+	ammo = "ctf_ranged:eammo",
+	fusion_mag = true
+})
+
+ctf_ranged.simple_register_gun("ctf_ranged:fusion_shotgun", {
+	type = "shotgun",
+	description = "Laser Shotgun (Fusion)",
+	texture = "rangedweapons_laser_shotgun.png",
+	fire_sound = "ctf_ranged_plasma",
+	bullet = {
+	   amount = 10,
+	   spread = 3.0,
+	},
+	rounds = 10,
+	range = 25,
+	damage = 2,
+	fire_interval = 0.65,
+	automatic = false,
+	bullet_image = "ctf_ranged_ebullet",
+	bullethole_image = "ctf_ranged_ebullethole",
+	ammo = "ctf_ranged:eammo",
+	fusion_mag = true
 })

--- a/ctf_ranged/wep_logic.lua
+++ b/ctf_ranged/wep_logic.lua
@@ -121,6 +121,7 @@ function ctf_ranged.simple_register_gun(name, def)
 							    ammo = def.ammo or "ctf_ranged:ammo",
 								bullet_image = def.bullet_image,
 								bullethole_image = def.bullethole_image,
+								fusion_mag = def.fusion_mag or false,
 							    rounds = def.rounds,
 							    _g_category = def.type,
 							    groups = {ranged = 1, [def.type] = 1, tier = def.tier or 1, not_in_creative_inventory = nil},
@@ -147,6 +148,7 @@ function ctf_ranged.simple_register_gun(name, def)
 							    loaded_def.inventory_overlay = def.texture_overlay
 							    loaded_def.wield_image = def.wield_texture or def.texture
 							    loaded_def.groups.not_in_creative_inventory = 1
+								loaded_def.fusion_mag = def.fusion_mag or false,
 								loaded_def.bullet_image = def.bullet_image
 								loaded_def.bullethole_image = def.bullethole_image
 							    loaded_def.on_use = function(itemstack, user)

--- a/ctf_ranged/wep_logic.lua
+++ b/ctf_ranged/wep_logic.lua
@@ -148,7 +148,7 @@ function ctf_ranged.simple_register_gun(name, def)
 							    loaded_def.inventory_overlay = def.texture_overlay
 							    loaded_def.wield_image = def.wield_texture or def.texture
 							    loaded_def.groups.not_in_creative_inventory = 1
-								loaded_def.fusion_mag = def.fusion_mag or false,
+								loaded_def.fusion_mag = def.fusion_mag or false
 								loaded_def.bullet_image = def.bullet_image
 								loaded_def.bullethole_image = def.bullethole_image
 							    loaded_def.on_use = function(itemstack, user)


### PR DESCRIPTION
This allows Energy weapons to be upgraded into somewhat fancy guns.

Features:

- Fusion Energy weapons are able to reload themselves without any ammo costs, unless you fully unload the gun (switch to another gun and let that one reload)
- Fusion Energy weapons have a simple but somewhat expensive upgrade cost. (Takes another gunpart for Energy weapons but I think it's worth it)
- Fusion Energy weapons are identical to the current Energy weapons as far as damage, fire rate, accuracy, range. etc.

> P.S. Fusion Energy weapons require you the player to work properly, so you can't just drop it into a chest and expect it to reload still. (Everything must have Pros and Cons)