### PR TITLE
Added Milkor grenade launcher

### DIFF
--- a/ctf_ranged/wep_defns.lua
+++ b/ctf_ranged/wep_defns.lua
@@ -386,6 +386,21 @@ ctf_ranged.simple_register_gun("ctf_ranged:m79", {
 				  on_fire_callback=launch_grenade
 })
 
+ctf_ranged.simple_register_gun("ctf_ranged:milkor", {
+	type = "pistol",
+	description = "Milkor",
+	texture = "rangedweapons_milkor.png",
+	fire_sound = "ctf_ranged_ashotfir",
+	ammo="ctf_ranged:40mm",
+	rounds = 6,
+	range = 50,
+	damage = 3,
+	automatic = true,
+	fire_interval = 0.4,
+	liquid_travel_dist = 3,
+	on_fire_callback=launch_grenade
+})
+
 --------------------------
 -- Energy weapons
 --------------------------


### PR DESCRIPTION
  Since it's been awhile I figured let's add one of the deadly grenade
launchers.

Fully automatic to make it even more deadly, 6 rounds just like it should, and reuses the M79's settings just modified some for the full auto.

 ---

## Great ideas follow

Ever wondered how to make more recipes to support crafting a Python? Or that cool Golden Desert Eagle? Or maybe that G11?

  > I'm wondering if we could use the grenade ammo (40mm) in the
crafting recipe for the grenade launchers?

  > For weapons like the Golden Desert Eagle we could simply
require gold blocks to "upgrade" a regular Desert Eagle to this super
cool looking version. This could apply say iron blocks to "upgrade" the
Desert Eagle into the Python too, (Kind of like upgrade options for the
tier 3s)

  > We could put some kind of resource cost onto say the Intervention
(m200) and have it "upgrade" to the G11?

  > And maybe a bunch of 40mm grenades placed with a M79 to "upgrade" to
the Milkor?